### PR TITLE
fix: function name

### DIFF
--- a/.changeset/slow-canyons-double.md
+++ b/.changeset/slow-canyons-double.md
@@ -1,0 +1,5 @@
+---
+'@cfxjs/sirius-next-common': patch
+---
+
+fix: function name

--- a/.github/workflows/test-on-main-merge.yml
+++ b/.github/workflows/test-on-main-merge.yml
@@ -1,0 +1,44 @@
+name: Test On Main Merge
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    name: Run All Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.5.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run all tests in workspace
+        run: pnpm -r --if-present test

--- a/packages/common/src/utils/hooks/useDecodeFunctionData.ts
+++ b/packages/common/src/utils/hooks/useDecodeFunctionData.ts
@@ -45,7 +45,7 @@ const decodeFunctionDataByAbi = ({
       ? !isReturnDataEmpty
         ? decodeFunctionResult({
             abi: abi,
-            functionName: decodedParams.functionName,
+            functionName: methodID,
             data: output,
             space,
           })
@@ -53,7 +53,7 @@ const decodeFunctionDataByAbi = ({
       : output;
     const abiItem = getAbiItem({
       abi: abi,
-      name: decodedParams.functionName ?? methodID,
+      name: methodID,
     }) as AbiFunctionWithoutGas;
     // if the output has only one value, decodeFunctionResult will return the value directly, otherwise it will return an array,
     // so we need to check the length of abiItem.outputs to determine whether to wrap decodedResults in an array

--- a/packages/common/src/utils/sdk.test.ts
+++ b/packages/common/src/utils/sdk.test.ts
@@ -69,6 +69,26 @@ const testAbi: Abi = [
   },
 ];
 
+const overloadedResultAbi: Abi = [
+  {
+    type: 'function',
+    name: 'calc',
+    inputs: [{ name: 'a', type: 'uint256' }],
+    outputs: [{ name: 'value', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    name: 'calc',
+    inputs: [
+      { name: 'a', type: 'uint256' },
+      { name: 'b', type: 'uint256' },
+    ],
+    outputs: [{ name: 'ok', type: 'bool' }],
+    stateMutability: 'view',
+  },
+];
+
 describe('decodeFunctionData', () => {
   let decodeFunctionData: Awaited<
     ReturnType<typeof getSdk>
@@ -182,6 +202,90 @@ describe('decodeFunctionResult', () => {
       space: 'core',
     });
     expect(result).toEqual(99999n);
+  });
+
+  test('evm: decodes function result when functionName is methodId', () => {
+    const encoded = encodeFunctionResult({
+      abi: testAbi,
+      functionName: 'getValue',
+      result: 54321n,
+    });
+    const methodId = toFunctionSelector('getValue(uint256)');
+
+    const result = decodeFunctionResult({
+      data: encoded,
+      abi: testAbi,
+      functionName: methodId,
+      space: 'evm',
+    });
+    expect(result).toEqual(54321n);
+  });
+
+  test('core: decodes function result when functionName is methodId', () => {
+    const encoded = encodeFunctionResult({
+      abi: testAbi,
+      functionName: 'getValue',
+      result: 888n,
+    });
+    const methodId = toFunctionSelector('getValue(uint256)');
+
+    const result = decodeFunctionResult({
+      data: encoded,
+      abi: testAbi,
+      functionName: methodId,
+      space: 'core',
+    });
+    expect(result).toEqual(888n);
+  });
+
+  test('evm: resolves overloaded function result by methodId', () => {
+    const encoded = encodeAbiParameters([{ name: 'ok', type: 'bool' }], [true]);
+    const methodId = toFunctionSelector('calc(uint256,uint256)');
+
+    const result = decodeFunctionResult({
+      data: encoded,
+      abi: overloadedResultAbi,
+      functionName: methodId,
+      space: 'evm',
+    });
+    expect(result).toBe(true);
+  });
+
+  test('core: resolves overloaded function result by methodId', () => {
+    const encoded = encodeAbiParameters([{ name: 'ok', type: 'bool' }], [true]);
+    const methodId = toFunctionSelector('calc(uint256,uint256)');
+
+    const result = decodeFunctionResult({
+      data: encoded,
+      abi: overloadedResultAbi,
+      functionName: methodId,
+      space: 'core',
+    });
+    expect(result).toBe(true);
+  });
+
+  test('evm: decodes empty output for no-return function by methodId', () => {
+    const methodId = toFunctionSelector('setValues(uint256,uint256)');
+
+    const result = decodeFunctionResult({
+      data: '0x',
+      abi: testAbi,
+      functionName: methodId,
+      space: 'evm',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test('core: decodes empty output for no-return function by methodId', () => {
+    const methodId = toFunctionSelector('setValues(uint256,uint256)');
+
+    const result = decodeFunctionResult({
+      data: '0x',
+      abi: testAbi,
+      functionName: methodId,
+      space: 'core',
+    });
+    expect(result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
This pull request addresses a bug related to function name handling in the `@cfxjs/sirius-next-common` package. The main fix ensures that the correct function identifier (`methodID`) is used instead of the previously decoded function name when interacting with ABI-related utilities.

Function name handling fix:

* Updated `decodeFunctionDataByAbi` in `useDecodeFunctionData.ts` to use `methodID` instead of `decodedParams.functionName` when calling `decodeFunctionResult` and `getAbiItem`, ensuring more accurate ABI function resolution.

Changelog update:

* Added a changeset file documenting the function name fix for the `@cfxjs/sirius-next-common` package.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Conflux-Chain/sirius-next/163)
<!-- Reviewable:end -->
